### PR TITLE
Setting subunit_to_unit for CLP to 100

### DIFF
--- a/config/currency_iso.json
+++ b/config/currency_iso.json
@@ -452,7 +452,7 @@
     "disambiguate_symbol": "CLP",
     "alternate_symbols": [],
     "subunit": "Peso",
-    "subunit_to_unit": 1,
+    "subunit_to_unit": 100,
     "symbol_first": true,
     "html_entity": "&#36;",
     "decimal_mark": ",",


### PR DESCRIPTION
The smallest unit for a chilean peso is supposed to be 1 centavo.
While these are out of circulation the 1:1 subunit:unit setting is
causing incorrect conversions to other currencies.  My findings are
explained in more detail here
https://github.com/RubyMoney/google_currency/issues/38
